### PR TITLE
Add MQTT TLS toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ Set the **MONGO_CONNECTION_STRING** environment variable to connect to your loca
 export MONGO_CONNECTION_STRING="mongodb://localhost:27017"
 ```
 
+If you want to publish data to a local MQTT broker without TLS, set
+`OPENF1_MQTT_USE_TLS=0` (defaults to `1`).
+
 5. Run the project
 
 - Fetch and ingest data: [services/ingestor_livetiming/](src/openf1/services/ingestor_livetiming/README.md)

--- a/examples/replay_historical_to_mqtt.py
+++ b/examples/replay_historical_to_mqtt.py
@@ -1,3 +1,8 @@
+"""Replay historical session data to an MQTT broker.
+
+Set ``OPENF1_MQTT_USE_TLS=0`` when connecting to a local broker without TLS.
+"""
+
 import asyncio
 import json
 

--- a/src/openf1/util/mqtt.py
+++ b/src/openf1/util/mqtt.py
@@ -9,13 +9,18 @@ _port = int(os.getenv("OPENF1_MQTT_PORT"))
 _username = os.getenv("OPENF1_MQTT_USERNAME")
 _password = os.getenv("OPENF1_MQTT_PASSWORD")
 
+_use_tls_env = os.getenv("OPENF1_MQTT_USE_TLS", "1").strip().lower()
+_use_tls = _use_tls_env not in ("0", "false", "no")
+
 _client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
 _client.username_pw_set(_username, _password)
-_client.tls_set(
-    ca_certs=None,
-    cert_reqs=ssl.CERT_REQUIRED,
-    tls_version=ssl.PROTOCOL_TLS_CLIENT,
-)
+if _use_tls:
+    _client.tls_set(
+        ca_certs=None,
+        cert_reqs=ssl.CERT_REQUIRED,
+        tls_version=ssl.PROTOCOL_TLS_CLIENT,
+    )
+logger.info(f"MQTT TLS {'enabled' if _use_tls else 'disabled'}")
 
 try:
     logger.info(f"Connecting to MQTT broker {_url}:{_port}...")


### PR DESCRIPTION
## Summary
- allow disabling MQTT TLS via `OPENF1_MQTT_USE_TLS`
- document the `OPENF1_MQTT_USE_TLS` environment variable
- hint on disabling TLS in `replay_historical_to_mqtt.py`

## Testing
- `ruff check --output-format=github --ignore=E501,E722 --target-version=py310 .`
- `black --check --diff --color .`


------
https://chatgpt.com/codex/tasks/task_e_68555271a6408321a9f098cbaaf6d282